### PR TITLE
Add SQL formatter Flask utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 __pycache__/
 *.pyc
 .DS_Store
+.venv/
+venv/

--- a/sql-formatter/README.md
+++ b/sql-formatter/README.md
@@ -1,0 +1,26 @@
+# SQL Formatter
+
+A tiny web app to format SQL queries using [sqlparse](https://github.com/andialbrecht/sqlparse).
+
+## Features
+
+- Paste SQL or upload a `.sql` file
+- Choose keyword case (upper/lower/as-is)
+- Light/Dark theme toggle
+- Download or copy the formatted SQL
+
+## Setup
+
+```bash
+bash setup.sh
+source venv/bin/activate  # if not already activated
+python app.py
+```
+
+Then open <http://localhost:5000> in a browser.
+
+## Tests
+
+```bash
+python -m pytest -q
+```

--- a/sql-formatter/app.py
+++ b/sql-formatter/app.py
@@ -1,0 +1,79 @@
+import os
+from flask import (
+    Flask,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+    session,
+    Response,
+)
+
+from formatting import format_sql
+
+app = Flask(__name__)
+app.secret_key = os.environ.get("SECRET_KEY", "dev-secret")
+MAX_UPLOAD_SIZE = 1 * 1024 * 1024  # 1MB
+ALLOWED_EXTENSIONS = {".sql"}
+
+
+def _read_uploaded_file(file_storage):
+    filename = file_storage.filename
+    _, ext = os.path.splitext(filename)
+    if ext.lower() not in ALLOWED_EXTENSIONS:
+        raise ValueError("Only .sql files are allowed")
+    data = file_storage.read()
+    if len(data) > MAX_UPLOAD_SIZE:
+        raise ValueError("File too large")
+    return data.decode("utf-8")
+
+
+@app.route("/", methods=["GET"])
+def index():
+    return render_template("index.html")
+
+
+@app.route("/format", methods=["POST"])
+def format_route():
+    keyword_case = request.form.get("keyword_case", "upper")
+    text = request.form.get("sql_text", "")
+    file = request.files.get("sql_file")
+
+    if file and file.filename:
+        try:
+            text = _read_uploaded_file(file)
+        except Exception as exc:  # pragma: no cover - defensive
+            flash(str(exc))
+            return redirect(url_for("index"))
+
+    text = text.strip()
+    if not text:
+        flash("Please provide SQL text or upload a .sql file.")
+        return redirect(url_for("index"))
+
+    try:
+        formatted = format_sql(text, keyword_case)
+    except Exception:  # pragma: no cover - sqlparse rarely fails
+        flash("Failed to parse SQL.")
+        return redirect(url_for("index"))
+
+    session["formatted_sql"] = formatted
+    return render_template("result.html", formatted_sql=formatted)
+
+
+@app.route("/download")
+def download():
+    formatted = session.get("formatted_sql")
+    if formatted is None:
+        flash("No formatted SQL available.")
+        return redirect(url_for("index"))
+    return Response(
+        formatted,
+        mimetype="text/plain",
+        headers={"Content-Disposition": "attachment; filename=formatted.sql"},
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app.run(debug=True)

--- a/sql-formatter/formatting.py
+++ b/sql-formatter/formatting.py
@@ -1,0 +1,16 @@
+import sqlparse
+
+
+def format_sql(text: str, keyword_case: str = "upper") -> str:
+    """Format SQL text using sqlparse.
+
+    Args:
+        text: Raw SQL string.
+        keyword_case: 'upper', 'lower', or 'default'.
+
+    Returns:
+        Formatted SQL string.
+    """
+    text = text or ""
+    case = None if keyword_case == "default" else keyword_case
+    return sqlparse.format(text, reindent=True, keyword_case=case)

--- a/sql-formatter/requirements.txt
+++ b/sql-formatter/requirements.txt
@@ -1,0 +1,3 @@
+flask
+sqlparse
+pytest

--- a/sql-formatter/setup.sh
+++ b/sql-formatter/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ ! -d "venv" ]; then
+  python3 -m venv venv
+fi
+source venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt

--- a/sql-formatter/static/app.js
+++ b/sql-formatter/static/app.js
@@ -1,0 +1,30 @@
+(function () {
+  const root = document.documentElement;
+  const toggle = document.getElementById('theme-toggle');
+
+  function setTheme(theme) {
+    root.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }
+
+  const stored = localStorage.getItem('theme') || 'light';
+  setTheme(stored);
+
+  if (toggle) {
+    toggle.addEventListener('click', function () {
+      const current = root.getAttribute('data-theme');
+      const next = current === 'light' ? 'dark' : 'light';
+      setTheme(next);
+    });
+  }
+
+  const copyBtn = document.getElementById('copy-btn');
+  const pre = document.getElementById('formatted-sql');
+  if (copyBtn && pre) {
+    copyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(pre.innerText);
+      copyBtn.textContent = 'Copied!';
+      setTimeout(() => (copyBtn.textContent = 'Copy to clipboard'), 1500);
+    });
+  }
+})();

--- a/sql-formatter/static/styles.css
+++ b/sql-formatter/static/styles.css
@@ -1,0 +1,72 @@
+:root {
+  --bg: #ffffff;
+  --fg: #000000;
+  --code-bg: #f0f0f0;
+}
+
+[data-theme='dark'] {
+  --bg: #1e1e1e;
+  --fg: #f5f5f5;
+  --code-bg: #2d2d2d;
+}
+
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: sans-serif;
+  margin: 0;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+textarea, pre {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: monospace;
+  background: var(--code-bg);
+  color: var(--fg);
+  padding: 0.5rem;
+}
+
+.input-form label,
+.input-form select,
+.input-form button,
+.input-form input {
+  display: block;
+  margin-top: 0.5rem;
+}
+
+.actions {
+  margin-top: 1rem;
+}
+
+button,
+a.button {
+  padding: 0.5rem 1rem;
+  margin-right: 0.5rem;
+  background: #007bff;
+  color: #fff;
+  border: none;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.flash-messages {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem 0;
+  color: red;
+}

--- a/sql-formatter/templates/base.html
+++ b/sql-formatter/templates/base.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SQL Formatter</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
+  </head>
+  <body>
+    <header>
+      <h1><a href="{{ url_for('index') }}">SQL Formatter</a></h1>
+      <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+    </header>
+    <main>
+      {% with messages = get_flashed_messages() %}
+        {% if messages %}
+          <ul class="flash-messages">
+          {% for message in messages %}
+            <li>{{ message }}</li>
+          {% endfor %}
+          </ul>
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </main>
+    <script src="{{ url_for('static', filename='app.js') }}"></script>
+  </body>
+</html>

--- a/sql-formatter/templates/index.html
+++ b/sql-formatter/templates/index.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <form action="{{ url_for('format_route') }}" method="post" enctype="multipart/form-data" class="input-form">
+    <label for="sql_text">SQL</label>
+    <textarea id="sql_text" name="sql_text" rows="10" placeholder="select u.id, o.total\nfrom users u join orders o on o.user_id = u.id\nwhere o.status = 'paid' and o.total > 100\norder by o.total desc"></textarea>
+
+    <label for="sql_file">Or upload .sql file</label>
+    <input type="file" id="sql_file" name="sql_file" accept=".sql" />
+
+    <label for="keyword_case">Keyword case</label>
+    <select id="keyword_case" name="keyword_case">
+      <option value="upper" selected>UPPER</option>
+      <option value="lower">lower</option>
+      <option value="default">As-is</option>
+    </select>
+
+    <button type="submit">Format</button>
+  </form>
+{% endblock %}

--- a/sql-formatter/templates/result.html
+++ b/sql-formatter/templates/result.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <section class="result">
+    <pre id="formatted-sql">{{ formatted_sql }}</pre>
+    <div class="actions">
+      <button id="copy-btn">Copy to clipboard</button>
+      <a href="{{ url_for('download') }}" class="button">Download</a>
+    </div>
+  </section>
+{% endblock %}

--- a/sql-formatter/tests/test_formatting.py
+++ b/sql-formatter/tests/test_formatting.py
@@ -1,0 +1,23 @@
+from formatting import format_sql
+
+
+def test_uppercase_keywords():
+    sql = "select a from t"
+    formatted = format_sql(sql, keyword_case="upper")
+    assert "SELECT" in formatted
+    assert "FROM" in formatted
+
+
+def test_lowercase_keywords():
+    sql = "SELECT A FROM T"
+    formatted = format_sql(sql, keyword_case="lower")
+    assert "select" in formatted
+    assert "from" in formatted
+
+
+def test_default_case_preserved_with_indent():
+    sql = "SELECT a\nFROM t"
+    formatted = format_sql(sql, keyword_case="default")
+    assert "SELECT" in formatted and "FROM" in formatted
+    # ensure reindent added newline before FROM
+    assert formatted.strip().splitlines()[1].startswith("FROM")


### PR DESCRIPTION
## Summary
- add Flask-based SQL formatter app with keyword case selection and theme toggle
- implement helper using sqlparse and include basic unit tests
- provide setup script and documentation for running and testing

## Testing
- `bash setup.sh` *(fails: Could not find a version that satisfies the requirement flask)*
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlparse')*
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689d45f096e083228ed636766780976a